### PR TITLE
Fixed button, and fixed the margins

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 				background-repeat: repeat;
 				height: 100%;
   				display: grid;
+				margin: 0;
 			}
 
 			center

--- a/success.html
+++ b/success.html
@@ -7,6 +7,7 @@
 				background-repeat: repeat;
 				height: 100%;
   				display: grid;
+				margin: 0;
 			}
 
 			center
@@ -48,6 +49,9 @@
 				font-family: monospace;
 				font-size: 15px;
 			}
+			.below {
+				margin-top: 40px;
+			}
 		</style>
 		<title>S^X</title>
 	</head>
@@ -58,8 +62,8 @@
 			<br/>
 			<a href="https://mega.nz/#!vUN2hKwL!xHKofJeNr0kLLxK9JTLDMLQbxyZvP8tVISpba0KzalQ">
 				<button class="button button_dl">Download <b>Bootstrapper</b></button>
-			</a><br/><br/>
-			<p class="notice">If you have any issues, please contact our <a href="https://go.crisp.chat/chat/embed/?website_id=2496afc0-dc84-4ae6-9be2-0202e061e534">live support.</a></p>
+			</a><br /><br />
+			<p class="notice below">If you have any issues, please contact our <a href="https://go.crisp.chat/chat/embed/?website_id=2496afc0-dc84-4ae6-9be2-0202e061e534">live support.</a></p>
 		</center>
 	</body>
 


### PR DESCRIPTION
For some reason on chrome it seems to default the margin to 8 on all sides, thus creating an overflow, adding `margin: 0` fixes that. Also it seems that the `<br/>` element was causing an `_` next to the button, removing these and replacing it with a margin seemed to fix that.